### PR TITLE
finish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,4 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+target_compile_options(main PUBLIC -ffast-math -march=native)

--- a/main.s
+++ b/main.s
@@ -1,0 +1,660 @@
+	.file	"main.cpp"
+# GNU C++14 (Ubuntu 9.3.0-17ubuntu1~20.04) version 9.3.0 (x86_64-linux-gnu)
+#	compiled by GNU C version 9.3.0, GMP version 6.2.0, MPFR version 4.0.2, MPC version 1.1.0, isl version isl-0.22.1-GMP
+
+# GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
+# options passed:  -imultiarch x86_64-linux-gnu -D_GNU_SOURCE main.cpp
+# -march=icelake-client -mmmx -mno-3dnow -msse -msse2 -msse3 -mssse3
+# -mno-sse4a -mcx16 -msahf -mmovbe -maes -msha -mpclmul -mpopcnt -mabm
+# -mno-lwp -mfma -mno-fma4 -mno-xop -mbmi -mno-sgx -mbmi2 -mno-pconfig
+# -mno-wbnoinvd -mno-tbm -mavx -mavx2 -msse4.2 -msse4.1 -mlzcnt -mno-rtm
+# -mno-hle -mrdrnd -mf16c -mfsgsbase -mrdseed -mprfchw -madx -mfxsr -mxsave
+# -mxsaveopt -mavx512f -mno-avx512er -mavx512cd -mno-avx512pf
+# -mno-prefetchwt1 -mclflushopt -mxsavec -mxsaves -mavx512dq -mavx512bw
+# -mavx512vl -mavx512ifma -mavx512vbmi -mno-avx5124fmaps -mno-avx5124vnniw
+# -mno-clwb -mno-mwaitx -mno-clzero -mno-pku -mrdpid -mgfni -mno-shstk
+# -mavx512vbmi2 -mavx512vnni -mvaes -mvpclmulqdq -mavx512bitalg
+# -mavx512vpopcntdq -mno-movdiri -mno-movdir64b -mno-waitpkg -mno-cldemote
+# -mno-ptwrite --param l1-cache-size=48 --param l1-cache-line-size=64
+# --param l2-cache-size=16384 -mtune=generic -auxbase-strip main.s -O3
+# -fverbose-asm -fomit-frame-pointer -ffast-math
+# -fasynchronous-unwind-tables -fstack-protector-strong -Wformat
+# -Wformat-security -fstack-clash-protection -fcf-protection
+# options enabled:  -fPIC -fPIE -faggressive-loop-optimizations
+# -falign-functions -falign-jumps -falign-labels -falign-loops
+# -fassociative-math -fassume-phsa -fasynchronous-unwind-tables
+# -fauto-inc-dec -fbranch-count-reg -fcaller-saves -fcode-hoisting
+# -fcombine-stack-adjustments -fcommon -fcompare-elim -fcprop-registers
+# -fcrossjumping -fcse-follow-jumps -fcx-limited-range -fdefer-pop
+# -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively
+# -fdwarf2-cfi-asm -fearly-inlining -feliminate-unused-debug-types
+# -fexceptions -fexpensive-optimizations -ffinite-math-only
+# -fforward-propagate -ffp-int-builtin-inexact -ffunction-cse -fgcse
+# -fgcse-after-reload -fgcse-lm -fgnu-runtime -fgnu-unique
+# -fguess-branch-probability -fhoist-adjacent-loads -fident -fif-conversion
+# -fif-conversion2 -findirect-inlining -finline -finline-atomics
+# -finline-functions -finline-functions-called-once
+# -finline-small-functions -fipa-bit-cp -fipa-cp -fipa-cp-clone -fipa-icf
+# -fipa-icf-functions -fipa-icf-variables -fipa-profile -fipa-pure-const
+# -fipa-ra -fipa-reference -fipa-reference-addressable -fipa-sra
+# -fipa-stack-alignment -fipa-vrp -fira-hoist-pressure
+# -fira-share-save-slots -fira-share-spill-slots
+# -fisolate-erroneous-paths-dereference -fivopts -fkeep-static-consts
+# -fleading-underscore -flifetime-dse -floop-interchange
+# -floop-unroll-and-jam -flra-remat -flto-odr-type-merging
+# -fmerge-constants -fmerge-debug-strings -fmove-loop-invariants
+# -fomit-frame-pointer -foptimize-sibling-calls -foptimize-strlen
+# -fpartial-inlining -fpeel-loops -fpeephole -fpeephole2 -fplt
+# -fpredictive-commoning -fprefetch-loop-arrays -freciprocal-math -free
+# -freg-struct-return -freorder-blocks -freorder-blocks-and-partition
+# -freorder-functions -frerun-cse-after-loop
+# -fsched-critical-path-heuristic -fsched-dep-count-heuristic
+# -fsched-group-heuristic -fsched-interblock -fsched-last-insn-heuristic
+# -fsched-rank-heuristic -fsched-spec -fsched-spec-insn-heuristic
+# -fsched-stalled-insns-dep -fschedule-fusion -fschedule-insns2
+# -fsemantic-interposition -fshow-column -fshrink-wrap
+# -fshrink-wrap-separate -fsplit-ivs-in-unroller -fsplit-loops
+# -fsplit-paths -fsplit-wide-types -fssa-backprop -fssa-phiopt
+# -fstack-clash-protection -fstack-protector-strong -fstdarg-opt
+# -fstore-merging -fstrict-aliasing -fstrict-volatile-bitfields
+# -fsync-libcalls -fthread-jumps -ftoplevel-reorder -ftree-bit-ccp
+# -ftree-builtin-call-dce -ftree-ccp -ftree-ch -ftree-coalesce-vars
+# -ftree-copy-prop -ftree-cselim -ftree-dce -ftree-dominator-opts
+# -ftree-dse -ftree-forwprop -ftree-fre -ftree-loop-distribute-patterns
+# -ftree-loop-distribution -ftree-loop-if-convert -ftree-loop-im
+# -ftree-loop-ivcanon -ftree-loop-optimize -ftree-loop-vectorize
+# -ftree-parallelize-loops= -ftree-partial-pre -ftree-phiprop -ftree-pre
+# -ftree-pta -ftree-reassoc -ftree-scev-cprop -ftree-sink
+# -ftree-slp-vectorize -ftree-slsr -ftree-sra -ftree-switch-conversion
+# -ftree-tail-merge -ftree-ter -ftree-vrp -funit-at-a-time
+# -funsafe-math-optimizations -funswitch-loops -funwind-tables
+# -fverbose-asm -fversion-loops-for-strides -fzero-initialized-in-bss
+# -m128bit-long-double -m64 -m80387 -mabm -madx -maes -malign-stringops
+# -mavx -mavx2 -mavx256-split-unaligned-load -mavx256-split-unaligned-store
+# -mavx512bitalg -mavx512bw -mavx512cd -mavx512dq -mavx512f -mavx512ifma
+# -mavx512vbmi -mavx512vbmi2 -mavx512vl -mavx512vnni -mavx512vpopcntdq
+# -mbmi -mbmi2 -mclflushopt -mcx16 -mf16c -mfancy-math-387 -mfma
+# -mfp-ret-in-387 -mfsgsbase -mfxsr -mgfni -mglibc -mhle -mlong-double-80
+# -mlzcnt -mmmx -mmovbe -mpclmul -mpopcnt -mprfchw -mpush-args -mrdpid
+# -mrdrnd -mrdseed -mred-zone -msahf -msha -msse -msse2 -msse3 -msse4
+# -msse4.1 -msse4.2 -mssse3 -mstv -mtls-direct-seg-refs -mvaes -mvpclmulqdq
+# -mvzeroupper -mxsave -mxsavec -mxsaveopt -mxsaves
+
+	.text
+	.p2align 4
+	.globl	_Z4initv
+	.type	_Z4initv, @function
+_Z4initv:
+.LFB2020:
+	.cfi_startproc
+	endbr64	
+	pushq	%rbp	#
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	pushq	%rbx	#
+	.cfi_def_cfa_offset 24
+	.cfi_offset 3, -24
+	leaq	stars(%rip), %rbx	#, ivtmp.52
+	leaq	192(%rbx), %rbp	#, _59
+	subq	$8, %rsp	#,
+	.cfi_def_cfa_offset 32
+	.p2align 4,,10
+	.p2align 3
+.L2:
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp144
+	addq	$4, %rbx	#, ivtmp.52
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm2	#, tmp145
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp129, tmp144, tmp137
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm2, %xmm0	#, tmp145, _38
+# main.cpp:27:         stars.px[i] = frand();
+	vmovss	%xmm0, -4(%rbx)	# _38, MEM[base: _51, offset: 0]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp146
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm3	#, tmp147
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp130, tmp146, tmp138
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm3, %xmm0	#, tmp147, _34
+# main.cpp:28:         stars.py[i] = frand();
+	vmovss	%xmm0, 188(%rbx)	# _34, MEM[base: _51, offset: 192]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp148
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm4	#, tmp149
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp131, tmp148, tmp139
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm4, %xmm0	#, tmp149, _30
+# main.cpp:29:         stars.pz[i] = frand();
+	vmovss	%xmm0, 380(%rbx)	# _30, MEM[base: _51, offset: 384]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp150
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm5	#, tmp151
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp132, tmp150, tmp140
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm5, %xmm0	#, tmp151, _26
+# main.cpp:30:         stars.vx[i] = frand();
+	vmovss	%xmm0, 572(%rbx)	# _26, MEM[base: _51, offset: 576]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp152
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm6	#, tmp153
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp133, tmp152, tmp141
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm6, %xmm0	#, tmp153, _22
+# main.cpp:31:         stars.vy[i] = frand();
+	vmovss	%xmm0, 764(%rbx)	# _22, MEM[base: _51, offset: 768]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp154
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmovss	.LC1(%rip), %xmm7	#, tmp155
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp134, tmp154, tmp142
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vfmadd132ss	.LC0(%rip), %xmm7, %xmm0	#, tmp155, _18
+# main.cpp:32:         stars.vz[i] = frand();
+	vmovss	%xmm0, 956(%rbx)	# _18, MEM[base: _51, offset: 960]
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	call	rand@PLT	#
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vxorps	%xmm1, %xmm1, %xmm1	# tmp156
+	vcvtsi2ssl	%eax, %xmm1, %xmm0	# tmp135, tmp156, tmp143
+# main.cpp:9:     return (float)std::rand() / RAND_MAX * 2 - 1;
+	vmulss	.LC0(%rip), %xmm0, %xmm0	#, tmp124, tmp125
+# main.cpp:33:         stars.mass[i] = frand() + 1.0f;
+	vmovss	%xmm0, 1148(%rbx)	# tmp125, MEM[base: _51, offset: 1152]
+# main.cpp:26:     for (size_t i = 0; i < N; i++) {
+	cmpq	%rbp, %rbx	# _59, ivtmp.52
+	jne	.L2	#,
+# main.cpp:35: }
+	addq	$8, %rsp	#,
+	.cfi_def_cfa_offset 24
+	popq	%rbx	#
+	.cfi_def_cfa_offset 16
+	popq	%rbp	#
+	.cfi_def_cfa_offset 8
+	ret	
+	.cfi_endproc
+.LFE2020:
+	.size	_Z4initv, .-_Z4initv
+	.p2align 4
+	.globl	_Z4stepv
+	.type	_Z4stepv, @function
+_Z4stepv:
+.LFB2021:
+	.cfi_startproc
+	endbr64	
+# main.cpp:37: void step() {
+	leaq	stars(%rip), %rcx	#, vectp_stars.86
+# /usr/include/c++/9/cmath:464:   { return __builtin_sqrtf(__x); }
+	vxorps	%xmm10, %xmm10, %xmm10	# tmp154
+	vmovaps	.LC2(%rip), %zmm14	#, tmp207
+	vmovaps	.LC3(%rip), %zmm13	#, tmp208
+	vmovaps	.LC4(%rip), %zmm12	#, tmp209
+	leaq	192(%rcx), %rdx	#, tmp206
+	vmovss	.LC5(%rip), %xmm11	#, tmp210
+.L8:
+# main.cpp:43:         float pz = stars.pz[i];
+	vxorps	%xmm7, %xmm7, %xmm7	# vect_vz_50.97
+# main.cpp:41:         float px = stars.px[i];
+	vmovaps	(%rcx), %zmm17	# MEM[base: vectp_stars.86_104, offset: 0], vect_px_39.88
+# main.cpp:42:         float py = stars.py[i];
+	vmovaps	192(%rcx), %zmm16	# MEM[base: vectp_stars.86_104, offset: 192], vect_py_40.91
+	leaq	stars(%rip), %rax	#, ivtmp.144
+# main.cpp:43:         float pz = stars.pz[i];
+	vmovaps	384(%rcx), %zmm15	# MEM[base: vectp_stars.86_104, offset: 384], vect_pz_41.94
+	vmovaps	%zmm7, %zmm8	#, vect_vy_49.96
+	vmovaps	%zmm7, %zmm9	#, vect_vx_48.95
+	.p2align 4,,10
+	.p2align 3
+.L7:
+# main.cpp:48:             float dy = stars.py[j] - py;
+	vbroadcastss	192(%rax), %zmm5	# MEM[base: _120, offset: 192], tmp145
+# main.cpp:47:             float dx = stars.px[j] - px;
+	vbroadcastss	(%rax), %zmm6	# MEM[base: _120, offset: 0], tmp144
+	addq	$4, %rax	#, ivtmp.144
+# main.cpp:49:             float dz = stars.pz[j] - pz;
+	vbroadcastss	380(%rax), %zmm4	# MEM[base: _120, offset: 384], tmp146
+# main.cpp:48:             float dy = stars.py[j] - py;
+	vsubps	%zmm16, %zmm5, %zmm5	# vect_py_40.91, tmp145, vect_dy_43.99
+# main.cpp:47:             float dx = stars.px[j] - px;
+	vsubps	%zmm17, %zmm6, %zmm6	# vect_px_39.88, tmp144, vect_dx_42.98
+# main.cpp:49:             float dz = stars.pz[j] - pz;
+	vsubps	%zmm15, %zmm4, %zmm4	# vect_pz_41.94, tmp146, vect_dz_44.100
+# main.cpp:50:             float d2 = dx * dx + dy * dy + dz * dz + eps2;
+	vmulps	%zmm5, %zmm5, %zmm0	# vect_dy_43.99, vect_dy_43.99, vect_powmult_5.102
+	vmovaps	%zmm4, %zmm2	# vect_dz_44.100, _100
+	vfmadd132ps	%zmm4, %zmm14, %zmm2	# vect_dz_44.100, tmp207, _100
+	vfmadd231ps	%zmm6, %zmm6, %zmm0	# vect_dx_42.98, vect_dx_42.98, _96
+# main.cpp:50:             float d2 = dx * dx + dy * dy + dz * dz + eps2;
+	vaddps	%zmm2, %zmm0, %zmm2	# _100, _96, vect_d2_45.106
+# /usr/include/c++/9/cmath:464:   { return __builtin_sqrtf(__x); }
+	vcmpps	$4, %zmm2, %zmm10, %k1	#, vect_d2_45.106, tmp154, tmp155
+	vrsqrt14ps	%zmm2, %zmm1{%k1}{z}	# vect_d2_45.106, tmp149, tmp155,
+	vmulps	%zmm2, %zmm1, %zmm3	# vect_d2_45.106, tmp149, tmp150
+	vmulps	%zmm1, %zmm3, %zmm0	# tmp149, tmp150, tmp151
+	vmulps	%zmm12, %zmm3, %zmm3	# tmp209, tmp150, tmp153
+	vaddps	%zmm13, %zmm0, %zmm0	# tmp208, tmp151, tmp152
+	vmulps	%zmm3, %zmm0, %zmm0	# tmp153, tmp152, vect__58.107
+	vmulss	1148(%rax), %xmm11, %xmm3	# MEM[base: _120, offset: 1152], tmp210, _83
+# main.cpp:51:             d2 *= std::sqrt(d2);
+	vmulps	%zmm2, %zmm0, %zmm0	# vect_d2_45.106, vect__58.107, vect_d2_46.108
+# main.cpp:52:             float acc = stars.mass[j] * Gdt / d2;
+	vbroadcastss	%xmm3, %zmm3	# _83, vect__10.109
+# main.cpp:52:             float acc = stars.mass[j] * Gdt / d2;
+	vrcp14ps	%zmm0, %zmm1	# vect_d2_46.108, tmp162
+	vmulps	%zmm0, %zmm1, %zmm0	# vect_d2_46.108, tmp162, tmp163
+	vmulps	%zmm0, %zmm1, %zmm0	# tmp163, tmp162, tmp163
+	vaddps	%zmm1, %zmm1, %zmm1	# tmp162, tmp162, tmp164
+	vsubps	%zmm0, %zmm1, %zmm0	# tmp163, tmp164, tmp165
+	vmulps	%zmm0, %zmm3, %zmm0	# tmp165, vect__10.109, vect_acc_47.110
+# main.cpp:53:             vx += dx * acc;
+	vfmadd231ps	%zmm6, %zmm0, %zmm9	# vect_dx_42.98, vect_acc_47.110, vect_vx_48.95
+# main.cpp:54:             vy += dy * acc;
+	vfmadd231ps	%zmm5, %zmm0, %zmm8	# vect_dy_43.99, vect_acc_47.110, vect_vy_49.96
+# main.cpp:55:             vz += dz * acc;
+	vfmadd231ps	%zmm4, %zmm0, %zmm7	# vect_dz_44.100, vect_acc_47.110, vect_vz_50.97
+# main.cpp:45:         for (size_t j = 0; j < N; j++)
+	cmpq	%rdx, %rax	# tmp206, ivtmp.144
+	jne	.L7	#,
+# main.cpp:57:         stars.vx[i] += vx;
+	vaddps	576(%rcx), %zmm9, %zmm9	# MEM[base: vectp_stars.86_104, offset: 576], vect_vx_48.95, vect__15.123
+# main.cpp:58:         stars.vy[i] += vy;
+	vaddps	768(%rcx), %zmm8, %zmm8	# MEM[base: vectp_stars.86_104, offset: 768], vect_vy_49.96, vect__17.129
+	addq	$64, %rcx	#, vectp_stars.86
+# main.cpp:59:         stars.vz[i] += vz;
+	vaddps	896(%rcx), %zmm7, %zmm7	# MEM[base: vectp_stars.86_104, offset: 960], vect_vz_50.97, vect__19.135
+# main.cpp:57:         stars.vx[i] += vx;
+	vmovaps	%zmm9, 512(%rcx)	# vect__15.123, MEM[base: vectp_stars.86_104, offset: 576]
+# main.cpp:58:         stars.vy[i] += vy;
+	vmovaps	%zmm8, 704(%rcx)	# vect__17.129, MEM[base: vectp_stars.86_104, offset: 768]
+# main.cpp:59:         stars.vz[i] += vz;
+	vmovaps	%zmm7, 896(%rcx)	# vect__19.135, MEM[base: vectp_stars.86_104, offset: 960]
+	cmpq	%rax, %rcx	# ivtmp.144, vectp_stars.86
+	jne	.L8	#,
+# main.cpp:63:         stars.px[i] += stars.vx[i] * dt;
+	vmovaps	.LC6(%rip), %zmm0	#, tmp172
+	vmovaps	576+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 576], vect__22.63
+	vfmadd213ps	stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars], tmp172, vect__22.63
+# main.cpp:65:         stars.pz[i] += stars.vz[i] * dt;
+	vmovaps	512+stars(%rip), %zmm7	# MEM[(value_type &)&stars + 512], tmp221
+# main.cpp:63:         stars.px[i] += stars.vx[i] * dt;
+	vmovaps	%zmm1, stars(%rip)	# vect__22.63, MEM[(value_type &)&stars]
+# main.cpp:64:         stars.py[i] += stars.vy[i] * dt;
+	vmovaps	768+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 768], vect__25.73
+	vfmadd213ps	192+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 192], tmp172, vect__25.73
+	vmovaps	%zmm1, 192+stars(%rip)	# vect__25.73, MEM[(value_type &)&stars + 192]
+# main.cpp:65:         stars.pz[i] += stars.vz[i] * dt;
+	vmovaps	960+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 960], vect__28.83
+	vfmadd213ps	384+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 384], tmp172, vect__28.83
+	vmovaps	%zmm1, 384+stars(%rip)	# vect__28.83, MEM[(value_type &)&stars + 384]
+# main.cpp:63:         stars.px[i] += stars.vx[i] * dt;
+	vmovaps	640+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 640], vect__22.63
+	vfmadd213ps	64+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 64], tmp172, vect__22.63
+	vmovaps	%zmm1, 64+stars(%rip)	# vect__22.63, MEM[(value_type &)&stars + 64]
+# main.cpp:64:         stars.py[i] += stars.vy[i] * dt;
+	vmovaps	832+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 832], vect__25.73
+	vfmadd213ps	256+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 256], tmp172, vect__25.73
+	vmovaps	%zmm1, 256+stars(%rip)	# vect__25.73, MEM[(value_type &)&stars + 256]
+# main.cpp:65:         stars.pz[i] += stars.vz[i] * dt;
+	vmovaps	1024+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 1024], vect__28.83
+	vfmadd213ps	448+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 448], tmp172, vect__28.83
+	vmovaps	%zmm1, 448+stars(%rip)	# vect__28.83, MEM[(value_type &)&stars + 448]
+# main.cpp:63:         stars.px[i] += stars.vx[i] * dt;
+	vmovaps	704+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 704], vect__22.63
+	vfmadd213ps	128+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 128], tmp172, vect__22.63
+	vmovaps	%zmm1, 128+stars(%rip)	# vect__22.63, MEM[(value_type &)&stars + 128]
+# main.cpp:64:         stars.py[i] += stars.vy[i] * dt;
+	vmovaps	896+stars(%rip), %zmm1	# MEM[(value_type &)&stars + 896], vect__25.73
+	vfmadd213ps	320+stars(%rip), %zmm0, %zmm1	# MEM[(value_type &)&stars + 320], tmp172, vect__25.73
+# main.cpp:65:         stars.pz[i] += stars.vz[i] * dt;
+	vfmadd132ps	1088+stars(%rip), %zmm7, %zmm0	# MEM[(value_type &)&stars + 1088], tmp221, vect__28.83
+# main.cpp:64:         stars.py[i] += stars.vy[i] * dt;
+	vmovaps	%zmm1, 320+stars(%rip)	# vect__25.73, MEM[(value_type &)&stars + 320]
+# main.cpp:65:         stars.pz[i] += stars.vz[i] * dt;
+	vmovaps	%zmm0, 512+stars(%rip)	# vect__28.83, MEM[(value_type &)&stars + 512]
+	vzeroupper
+# main.cpp:67: }
+	ret	
+	.cfi_endproc
+.LFE2021:
+	.size	_Z4stepv, .-_Z4stepv
+	.p2align 4
+	.globl	_Z4calcv
+	.type	_Z4calcv, @function
+_Z4calcv:
+.LFB2022:
+	.cfi_startproc
+	endbr64	
+	leaq	stars(%rip), %r8	#, ivtmp.178
+# main.cpp:70:     float energy = 0.0f;
+	vxorps	%xmm10, %xmm10, %xmm10	# minus
+# main.cpp:71:     for (size_t i = 0; i < N; i++)
+	xorl	%esi, %esi	# i
+	vmovss	.LC8(%rip), %xmm12	#, tmp138
+	vmovss	.LC9(%rip), %xmm11	#, tmp139
+# main.cpp:69: float calc() {
+	movq	%r8, %rcx	# ivtmp.178, ivtmp.178
+	vmovss	.LC10(%rip), %xmm7	#, tmp141
+# main.cpp:70:     float energy = 0.0f;
+	vmovaps	%xmm10, %xmm9	# minus, <retval>
+# /usr/include/c++/9/cmath:464:   { return __builtin_sqrtf(__x); }
+	vmovss	.LC11(%rip), %xmm6	#, tmp142
+	vmovss	.LC12(%rip), %xmm5	#, tmp143
+	.p2align 4,,10
+	.p2align 3
+.L16:
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vmovss	768(%rcx), %xmm8	# MEM[base: _51, offset: 768], _77
+# main.cpp:74:         energy += stars.mass[i] * v2 / 2.0f;
+	movq	%r8, %rax	# ivtmp.178, ivtmp.171
+# main.cpp:76:         for (size_t j = 0; j < N; j++)
+	xorl	%edx, %edx	# j
+	leaq	1(%rsi), %rdi	#, i
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vmovss	576(%rcx), %xmm3	# MEM[base: _51, offset: 576], _79
+# main.cpp:74:         energy += stars.mass[i] * v2 / 2.0f;
+	vmovss	1152(%rcx), %xmm4	# MEM[base: _51, offset: 1152], _69
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vmulss	%xmm8, %xmm8, %xmm8	# _77, _77, tmp118
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vfmadd231ss	%xmm3, %xmm3, %xmm8	# _79, _79, _75
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vmovss	960(%rcx), %xmm3	# MEM[base: _51, offset: 960], _74
+# main.cpp:73:         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+	vfmadd231ss	%xmm3, %xmm3, %xmm8	# _74, _74, v2
+# main.cpp:74:         energy += stars.mass[i] * v2 / 2.0f;
+	vmulss	%xmm12, %xmm4, %xmm3	# tmp138, _69, tmp119
+	vmulss	%xmm11, %xmm4, %xmm4	# tmp139, _69, _66
+	vmulss	%xmm8, %xmm3, %xmm8	# v2, tmp119, _67
+# main.cpp:75:         float minus = 0.0f;
+	vmovaps	%xmm10, %xmm3	# minus, minus
+	.p2align 4,,10
+	.p2align 3
+.L15:
+# main.cpp:78:             if(i == j) continue;
+	cmpq	%rdx, %rsi	# j, i
+	je	.L12	#,
+# main.cpp:79:             float dx = stars.px[j] - stars.px[i];
+	vmovss	(%rax), %xmm1	# MEM[base: _63, offset: 0], MEM[base: _63, offset: 0]
+	vsubss	(%rcx), %xmm1, %xmm1	# MEM[base: _51, offset: 0], MEM[base: _63, offset: 0], dx
+# main.cpp:76:         for (size_t j = 0; j < N; j++)
+	addq	$1, %rdx	#, j
+	addq	$4, %rax	#, ivtmp.171
+# main.cpp:80:             float dy = stars.py[j] - stars.py[i];
+	vmovss	188(%rax), %xmm2	# MEM[base: _63, offset: 192], MEM[base: _63, offset: 192]
+	vsubss	192(%rcx), %xmm2, %xmm2	# MEM[base: _51, offset: 192], MEM[base: _63, offset: 192], dy
+# main.cpp:81:             float dz = stars.pz[j] - stars.pz[i];
+	vmovss	380(%rax), %xmm0	# MEM[base: _63, offset: 384], MEM[base: _63, offset: 384]
+	vsubss	384(%rcx), %xmm0, %xmm0	# MEM[base: _51, offset: 384], MEM[base: _63, offset: 384], dz
+# main.cpp:82:             float d2 = dx * dx + dy * dy + dz * dz + eps2;
+	vmulss	%xmm2, %xmm2, %xmm2	# dy, dy, tmp125
+	vfmadd132ss	%xmm0, %xmm7, %xmm0	# dz, tmp141, _112
+	vfmadd132ss	%xmm1, %xmm2, %xmm1	# dx, tmp125, _97
+# main.cpp:83:             minus += stars.mass[j] * stars.mass[i] * G / std::sqrt(d2) / 2.0f;
+	vmulss	1148(%rax), %xmm4, %xmm2	# MEM[base: _63, offset: 1152], _66, _129
+# main.cpp:82:             float d2 = dx * dx + dy * dy + dz * dz + eps2;
+	vaddss	%xmm0, %xmm1, %xmm0	# _112, _97, d2
+# /usr/include/c++/9/cmath:464:   { return __builtin_sqrtf(__x); }
+	vrsqrtss	%xmm0, %xmm0, %xmm1	# d2, tmp128
+	vmulss	%xmm0, %xmm1, %xmm0	# d2, tmp128, tmp129
+	vmulss	%xmm1, %xmm0, %xmm0	# tmp128, tmp129, tmp130
+	vmulss	%xmm5, %xmm1, %xmm1	# tmp143, tmp128, tmp132
+	vaddss	%xmm6, %xmm0, %xmm0	# tmp142, tmp130, tmp131
+	vmulss	%xmm1, %xmm0, %xmm0	# tmp132, tmp131, _130
+# main.cpp:83:             minus += stars.mass[j] * stars.mass[i] * G / std::sqrt(d2) / 2.0f;
+	vfmadd231ss	%xmm0, %xmm2, %xmm3	# _130, _129, minus
+# main.cpp:76:         for (size_t j = 0; j < N; j++)
+	cmpq	$48, %rdx	#, j
+	jne	.L15	#,
+.L13:
+# main.cpp:85:         energy -= minus;
+	vsubss	%xmm3, %xmm8, %xmm3	# minus, _67, tmp135
+# main.cpp:71:     for (size_t i = 0; i < N; i++)
+	movq	%rdi, %rsi	# i, i
+	addq	$4, %rcx	#, ivtmp.178
+# main.cpp:85:         energy -= minus;
+	vaddss	%xmm3, %xmm9, %xmm9	# tmp135, <retval>, <retval>
+# main.cpp:71:     for (size_t i = 0; i < N; i++)
+	cmpq	$48, %rdi	#, i
+	jne	.L16	#,
+# main.cpp:88: }
+	vmovaps	%xmm9, %xmm0	# <retval>,
+	ret	
+	.p2align 4,,10
+	.p2align 3
+.L12:
+# main.cpp:76:         for (size_t j = 0; j < N; j++)
+	movq	%rdi, %rdx	# i, j
+	addq	$4, %rax	#, ivtmp.171
+# main.cpp:76:         for (size_t j = 0; j < N; j++)
+	cmpq	$48, %rdi	#, i
+	jne	.L15	#,
+	jmp	.L13	#
+	.cfi_endproc
+.LFE2022:
+	.size	_Z4calcv, .-_Z4calcv
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.LC13:
+	.string	"Initial energy: %f\n"
+.LC14:
+	.string	"Final energy: %f\n"
+.LC15:
+	.string	"Time elapsed: %ld ms\n"
+	.section	.text.startup,"ax",@progbits
+	.p2align 4
+	.globl	main
+	.type	main, @function
+main:
+.LFB2024:
+	.cfi_startproc
+	endbr64	
+	pushq	%r12	#
+	.cfi_def_cfa_offset 16
+	.cfi_offset 12, -16
+# main.cpp:100:     init();
+	call	_Z4initv	#
+# main.cpp:101:     printf("Initial energy: %f\n", calc());
+	call	_Z4calcv	#
+# /usr/include/x86_64-linux-gnu/bits/stdio2.h:107:   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
+	movl	$1, %edi	#,
+	movl	$1, %eax	#,
+	leaq	.LC13(%rip), %rsi	#,
+# main.cpp:101:     printf("Initial energy: %f\n", calc());
+	vcvtss2sd	%xmm0, %xmm0, %xmm0	# tmp102, tmp94
+# /usr/include/x86_64-linux-gnu/bits/stdio2.h:107:   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
+	call	__printf_chk@PLT	#
+# main.cpp:92:     auto t0 = std::chrono::steady_clock::now();
+	call	_ZNSt6chrono3_V212steady_clock3nowEv@PLT	#
+	movl	$100000, %esi	#, ivtmp_12
+	movq	%rax, %r12	# tmp103, t0
+	.p2align 4,,10
+	.p2align 3
+.L25:
+# main.cpp:104:             step();
+	call	_Z4stepv	#
+# main.cpp:103:         for (int i = 0; i < 100000; i++)
+	subl	$1, %esi	#, ivtmp_12
+	jne	.L25	#,
+# main.cpp:94:     auto t1 = std::chrono::steady_clock::now();
+	call	_ZNSt6chrono3_V212steady_clock3nowEv@PLT	#
+# /usr/include/c++/9/chrono:153: 	      static_cast<_CR>(__d.count()) / static_cast<_CR>(_CF::den)));
+	movabsq	$4835703278458516699, %rdx	#, tmp97
+# /usr/include/c++/9/chrono:469: 	return __cd(__cd(__lhs).count() - __cd(__rhs).count());
+	subq	%r12, %rax	# t0, tmp104
+	movq	%rax, %rcx	# tmp104, tmp95
+# /usr/include/c++/9/chrono:153: 	      static_cast<_CR>(__d.count()) / static_cast<_CR>(_CF::den)));
+	imulq	%rdx	# tmp97
+	sarq	$63, %rcx	#, tmp99
+	sarq	$18, %rdx	#, tmp96
+	movq	%rdx, %r12	# tmp96, tmp98
+	subq	%rcx, %r12	# tmp99, _17
+# main.cpp:106:     printf("Final energy: %f\n", calc());
+	call	_Z4calcv	#
+# /usr/include/x86_64-linux-gnu/bits/stdio2.h:107:   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
+	movl	$1, %edi	#,
+	movl	$1, %eax	#,
+	leaq	.LC14(%rip), %rsi	#,
+# main.cpp:106:     printf("Final energy: %f\n", calc());
+	vcvtss2sd	%xmm0, %xmm0, %xmm0	# tmp105, tmp100
+# /usr/include/x86_64-linux-gnu/bits/stdio2.h:107:   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
+	call	__printf_chk@PLT	#
+	movq	%r12, %rdx	# _17,
+	xorl	%eax, %eax	#
+	leaq	.LC15(%rip), %rsi	#,
+	movl	$1, %edi	#,
+	call	__printf_chk@PLT	#
+# main.cpp:109: }
+	xorl	%eax, %eax	#
+	popq	%r12	#
+	.cfi_def_cfa_offset 8
+	ret	
+	.cfi_endproc
+.LFE2024:
+	.size	main, .-main
+	.globl	stars
+	.bss
+	.align 64
+	.type	stars, @object
+	.size	stars, 1344
+stars:
+	.zero	1344
+	.section	.rodata.cst4,"aM",@progbits,4
+	.align 4
+.LC0:
+	.long	813694976
+	.align 4
+.LC1:
+	.long	3212836864
+	.section	.rodata
+	.align 64
+.LC2:
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.long	897988542
+	.align 64
+.LC3:
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.long	3225419776
+	.align 64
+.LC4:
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.long	3204448256
+	.section	.rodata.cst4
+	.align 4
+.LC5:
+	.long	925353389
+	.section	.rodata
+	.align 64
+.LC6:
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.long	1008981770
+	.section	.rodata.cst4
+	.align 4
+.LC8:
+	.long	1056964608
+	.align 4
+.LC9:
+	.long	973279855
+	.align 4
+.LC10:
+	.long	897988542
+	.align 4
+.LC11:
+	.long	3225419776
+	.align 4
+.LC12:
+	.long	3204448256
+	.ident	"GCC: (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0"
+	.section	.note.GNU-stack,"",@progbits
+	.section	.note.gnu.property,"a"
+	.align 8
+	.long	 1f - 0f
+	.long	 4f - 1f
+	.long	 5
+0:
+	.string	 "GNU"
+1:
+	.align 8
+	.long	 0xc0000002
+	.long	 3f - 2f
+2:
+	.long	 0x3
+3:
+	.align 8
+4:


### PR DESCRIPTION
优化前
```
Initial energy: 20.288641
Final energy: 20.345922
Time elapsed: 875 ms
```
优化后
```
Initial energy: 20.288637
Final energy: 20.298662
Time elapsed: 79 ms
```

函数`calc`，计算引力势能似乎不应该加上自己对自己的，将`eps`调小后就会负几千，所以在`calc`函数中判断了一下是否是同一个物体，添加后该处附近的汇编不再能矢量化，但该函数只调用了两次，对时间不太影响。

1. 将AOS替换为SOA
使用`std::array`而不是`std::vector`，实测时间前者\~80ms，后者\~105ms
2. 循环中常量移到循环外
`G * dt`、`eps * eps`
3. 添加编译选项
优化好久从 800+ ms -> 500+ ms
加上编译选项 `-ffast-math -march=native` -> 80 ms
4. 似乎没用/不提速的优化
全局不变的常量加上`const`
所有数学常量改为表达式需要的类型 `2 -> 2.0f` 
`frand` 添加 `static`，得到的汇编文件不再有 `frand` 函数
需要累加的值定义临时变量累加，提高运算精度