### PR TITLE
final

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
-
 add_executable(main main.cpp)
+target_compile_options(main PUBLIC --fast-math -march=native -O3)
+find_package(OpenMP REQUIRED)
+target_link_libraries(main PUBLIC OpenMP::OpenMP_CXX)


### PR DESCRIPTION
环境：arch gcc11.1
初始结果忘记保存了，就记了个时间。。。。。。
Time elapsed: 1752 ms
结果：
Initial energy: 20.288641
Final energy: 20.298843
Time elapsed: 164 ms
加速手段：
1. 加上编译选项，包括--fast-math -march=native -O3 以及 OpenMP,效果从1000+到900+
2. 将struct结构体改成array,抛弃vector,效果从900+到800+，这也是最令我困惑一点，感觉从栈分配与堆分配并没有效果非常显著
3.将双层循环最内层中的数组下标的随即访问通过变量代替，放到外层循环成stars.vx[i] += vx. 这个效果是最好的直接从800+到170+。可能我凑巧打开了双层循环的simd加速？还是什么的，不过证明数组下标访问相当耗时。
4.使用#pragma GCC unroll N,对两个循环进行测试得出第一个循环N=16效果最好，第二个是8。非常玄学，完全不知道为什么，效果从170+-164ms
5.至于除法变乘法，加const / constexpr 则毫无用处，甚至还比不上多运行几次程序。但是我还是加了，哈哈。

