### PR TITLE
hw04 Ge-Lee

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 project(hellocmake LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
-if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-endif()
+set(CMAKE_BUILD_TYPE Release)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast " )
 
 add_executable(main main.cpp)


### PR DESCRIPTION
### 实验结果
**符号说明**
编译器：MSVC
> — — 表示使用了此优化方法
>  1 表示此优化有被执行

![image](https://user-images.githubusercontent.com/22428217/148382105-235361ab-f486-4ad5-b397-fbd89784cffe.png)

- 情况1：初始的耗时为3684ms;

-情况2： 使用 `std::array<>`来构建SOA模型结构，但是在未开-O3的状况下反而消耗更大了，属于是逆向优化。

- 情况3：仅仅使用 -O3优化，加速了3.58倍

- 情况4：-O3优化和  SOA使用，反而拖累了速度。
![image](https://user-images.githubusercontent.com/22428217/148383915-a067e6d0-0da6-4bd7-880a-68f9a83ba989.png)
查看汇编代码可知，编译器并没SIMD优化。

- 情况5：数学与循环相关优化：
 把不变的eps*eps挪动到循环外面来 | 数组求和的 reduction优化 |  将除法变为乘法 |   对于数学函数加上std::前缀

情况6：开启-ffast-math msvc对应的是 /fp: fast 
最终的加速是七倍，在写提交时才发现去检查SOA优化的汇编代码。只能周末再花时间优化一下。
