### PR TITLE
Submit hw04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,8 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if (MSVC)
+    add_compile_options(/fp:fast /Oi /Ot /Oy /GT /GL /FAs)
+endif()
+
 add_executable(main main.cpp)

--- a/main.cpp
+++ b/main.cpp
@@ -1,88 +1,193 @@
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
 #include <chrono>
 #include <cmath>
+#include <immintrin.h>
+#include <utility>
+#include <array>
 
-float frand() {
-    return (float)rand() / RAND_MAX * 2 - 1;
-}
+constexpr size_t STAR_NUM = 48;
+constexpr size_t SIMD_WIDTH = 16;  //16 floats
+constexpr size_t STAR_16_NUM = (STAR_NUM + SIMD_WIDTH - 1) / SIMD_WIDTH;
 
-struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+constexpr float G = 0.001;
+constexpr float eps = 0.001;
+constexpr float dt = 0.01;
+constexpr float G_dt = G * dt;
+
+const __m512 eps2 = _mm512_set1_ps(eps * eps);
+const __m512 vec_dt = _mm512_set1_ps(dt);
+const __m512 vec_G_dt = _mm512_set1_ps(G_dt);
+
+//Layout: AoSoA
+struct Star_16 {
+	alignas(64) __m512 vx;
+	alignas(64) __m512 vy;
+	alignas(64) __m512 vz;
+
+	alignas(64) __m512 px;
+	alignas(64) __m512 py;
+	alignas(64) __m512 pz;
+
+	alignas(64) __m512 mass;
 };
 
-std::vector<Star> stars;
+std::array<Star_16, STAR_16_NUM> stars;
 
-void init() {
-    for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
-    }
+static float frand() {
+	return (float)rand() / RAND_MAX * 2 - 1;
 }
 
-float G = 0.001;
-float eps = 0.001;
-float dt = 0.01;
+void init() {
+	for (int i = 0; i < stars.size(); i++) {
+		for (int j = 0; j < SIMD_WIDTH; j++) {
+			stars[i].px.m512_f32[j] = frand();
+			stars[i].py.m512_f32[j] = frand();
+			stars[i].pz.m512_f32[j] = frand();
+			stars[i].vx.m512_f32[j] = frand();
+			stars[i].vy.m512_f32[j] = frand();
+			stars[i].vz.m512_f32[j] = frand();
+			stars[i].mass.m512_f32[j] = frand() + 1;
+		}
+	}
+}
+
+template<class Fn, size_t... M>
+__forceinline static void unroll_impl(Fn fn, size_t L, std::integer_sequence<size_t, M...> iter) {
+	constexpr auto S = sizeof...(M);
+	if (L == 1) {
+		((fn(M)), ...);
+	}
+	else {
+		for (size_t i = 0; i < L; i++) {
+			((fn(M + i * S)), ...);
+		}
+	}
+}
+
+template<size_t N, size_t S = N, class Fn>   // N: total iterations, S = iterations per loop. S==N implies unrolling completely
+__forceinline constexpr static void UNROLL(Fn fn) {
+	static_assert(N % S == 0);
+	unroll_impl(fn, N / S, std::make_index_sequence<S>());
+}
 
 void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
-        }
-    }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
-    }
+	std::array<__m512, STAR_16_NUM> d_vx{};
+	std::array<__m512, STAR_16_NUM> d_vy{};
+	std::array<__m512, STAR_16_NUM> d_vz{};
+	for (size_t j = 0; j < stars.size(); ++j) {
+		auto& star_j = stars[j];
+		for (size_t k = 0; k < SIMD_WIDTH; ++k) {
+			__m512 px_jk = _mm512_set1_ps(star_j.px.m512_f32[k]);
+			__m512 py_jk = _mm512_set1_ps(star_j.py.m512_f32[k]);
+			__m512 pz_jk = _mm512_set1_ps(star_j.pz.m512_f32[k]);
+			__m512 mass_jk = _mm512_set1_ps(star_j.mass.m512_f32[k]);
+
+			UNROLL<stars.size()>([&](size_t i) {  //unrolling size: 3/1
+				__m512 dx = _mm512_sub_ps(px_jk, stars[i].px);
+				__m512 dy = _mm512_sub_ps(py_jk, stars[i].py);
+				__m512 dz = _mm512_sub_ps(pz_jk, stars[i].pz);
+				//float dx = px[j] - px[i];
+				//float dy = py[j] - py[i];
+				//float dz = pz[j] - pz[i];
+
+				__m512 prod = _mm512_mul_ps(dx, dx);
+				prod = _mm512_fmadd_ps(dy, dy, prod);
+				prod = _mm512_fmadd_ps(dz, dz, prod);
+				prod = _mm512_add_ps(eps2, prod);
+				//float prod = dx * dx + dy * dy + dz * dz + eps * eps;
+
+				__m512 inverse_sqrt = _mm512_rsqrt14_ps(prod);  // an approximate version of _mm512_invsqrt_ps 
+				__m512 inverse_sqrt2 = _mm512_mul_ps(inverse_sqrt, inverse_sqrt);
+				__m512 inverse_sqrt3 = _mm512_mul_ps(inverse_sqrt2, inverse_sqrt);
+				//float inverse_sqrt3 = 1 / sqrt(prod)^3;
+
+				__m512 factor = _mm512_mul_ps(inverse_sqrt3, mass_jk);
+				//float factor = mass[j] / sqrt(prod)^3;
+
+				d_vx[i] = _mm512_fmadd_ps(dx, factor, d_vx[i]);
+				d_vy[i] = _mm512_fmadd_ps(dy, factor, d_vy[i]);
+				d_vz[i] = _mm512_fmadd_ps(dz, factor, d_vz[i]);
+				//d_vx += dx * factor;
+				//d_vy += dy * factor; 
+				//d_vz += dz * factor; 
+				});
+			}
+		}
+
+	UNROLL<stars.size()>([&](size_t i) {   //unrolling size: 3/1
+		stars[i].vx = _mm512_fmadd_ps(d_vx[i], vec_G_dt, stars[i].vx);
+		stars[i].vy = _mm512_fmadd_ps(d_vy[i], vec_G_dt, stars[i].vy);
+		stars[i].vz = _mm512_fmadd_ps(d_vz[i], vec_G_dt, stars[i].vz);
+		//vx[i] += d_vx * G * dt;
+		//vy[i] += d_vy * G * dt;
+		//vz[i] += d_vz * G * dt;
+
+		stars[i].px = _mm512_fmadd_ps(stars[i].vx, vec_dt, stars[i].px);
+		stars[i].py = _mm512_fmadd_ps(stars[i].vy, vec_dt, stars[i].py);
+		stars[i].pz = _mm512_fmadd_ps(stars[i].vz, vec_dt, stars[i].pz);
+		//px[i] += vx[i] * dt;
+		//py[i] += vy[i] * dt;
+		//pz[i] += vz[i] * dt;
+		});
 }
 
 float calc() {
-    float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
-        }
-    }
-    return energy;
+	float energy = 0.f;
+	const float half_G = G * 0.5;
+	for (size_t i = 0; i < stars.size(); i++) {
+		auto const& star_i = stars[i];
+
+		for (size_t k = 0; k < SIMD_WIDTH; k++) {
+			const float px = star_i.px.m512_f32[k];
+			const float py = star_i.py.m512_f32[k];
+			const float pz = star_i.pz.m512_f32[k];
+			const float vx = star_i.vx.m512_f32[k];
+			const float vy = star_i.vy.m512_f32[k];
+			const float vz = star_i.vz.m512_f32[k];
+			const float mass_ik = star_i.mass.m512_f32[k];
+
+			const float v2 = vx * vx + vy * vy + vz * vz;
+			energy += mass_ik * v2 / 2;
+			float delta_e = 0.f;
+
+			for (size_t j = 0; j < stars.size(); j++) {
+				auto const& star_j = stars[j];
+
+				for (size_t m = 0; m < SIMD_WIDTH; m++) {
+					if (!(i == j && k == m)) {
+						const float dx = star_j.px.m512_f32[m] - px;
+						const float dy = star_j.py.m512_f32[m] - py;
+						const float dz = star_j.pz.m512_f32[m] - pz;
+						const float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
+						delta_e += star_j.mass.m512_f32[m] / sqrt(d2);
+					}
+				}
+			}
+			energy -= delta_e * mass_ik * half_G;
+		}
+	}
+	return energy;
 }
 
 template <class Func>
-long benchmark(Func const &func) {
-    auto t0 = std::chrono::steady_clock::now();
-    func();
-    auto t1 = std::chrono::steady_clock::now();
-    auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
-    return dt.count();
+long long benchmark(Func const& func) {
+	auto t0 = std::chrono::high_resolution_clock::now();
+	func();
+	auto t1 = std::chrono::high_resolution_clock::now();
+	auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
+	return dt.count();
 }
 
 int main() {
-    init();
-    printf("Initial energy: %f\n", calc());
-    auto dt = benchmark([&] {
-        for (int i = 0; i < 100000; i++)
-            step();
-    });
-    printf("Final energy: %f\n", calc());
-    printf("Time elapsed: %ld ms\n", dt);
-    return 0;
+	init();
+	printf("Initial energy: %f\n", calc());  // Initial energy: -8.571527
+	auto const dt = benchmark([&] {
+		for (size_t i = 0; i < 100000; i++)
+			step();
+		});
+	printf("Final energy: %f\n", calc());  // Final energy: -8.562095
+	printf("Time elapsed: %lld ms\n", dt);
+	//system("pause");
+	return 0;
 }


### PR DESCRIPTION
## 测试环境
- 系统：Windows10, 64 bit
- 编译器：MSVC 14.31 (Visual Studio 2022 Version 17.1)
- CPU：Intel Core i7-11800H @ 2.30GHz

## 加速结果
16 倍

原始版
```
Initial energy: -8.571527
Final energy: -8.511734
Time elapsed: 836 ms
```

优化版（AoSoA / AVX512 / Loop Unrolling）
```
Initial energy: 23.911722
Final energy: 23.921297
Time elapsed: 52 ms
```

## 基本优化
- 使用 Intrinsics 进行 SIMD 并行：优先使用 FMA 指令，计算 `1 / sqrt(r)^3` 时使用一次平方根倒数和两次乘法运算。将无法内联的 `_mm512_invsqrt_ps` 换成了 `_mm512_rsqrt14_ps`，经测试最终结果无影响
- 交换 `step()` 里的内外层循环：消除了规约求和，使向量化程度达到 100%
- 尽可能将循环体内的常量提出循环外：`mass` 可提出内层循环，`G*dt`可提出外层循环，从而减少不必要的计算
  
## 实验内容
- 数据布局：AoSoA 与 SoA
- SIMD 指令集：AVX512 与 AVX2
- 循环展开（编译器不支持，利用模板手动展开）
  
## 实验结果
```
SoA / AVX2 
Time elapsed: 57 ms

SoA / AVX2 / Loop Unrolling
Time elapsed: 62 ms

SoA / AVX512 
Time elapsed: 56 ms

SoA / AVX512 / Loop Unrolling
Time elapsed: 56 ms

AoSoA / AVX2 
Time elapsed: 55 ms

AoSoA / AVX2 / Loop Unrolling
Time elapsed: 53 ms

AoSoA / AVX512 
Time elapsed: 52 ms

AoSoA / AVX512 / Loop Unrolling
Time elapsed: 52 ms
```
## 结果分析
从结果来看，AoSoA 的数据布局稍稍好于 SoA。`step()` 的访存特征是 x,y,z 三个分量依次访问，AoSoA 对缓存更加友好。不过无论是 AoSoA 还是 SoA，VTune profiler 的结果表明，程序主要是 core bound (meomery bound slots<1%)，因此二者差别不大。

循环展开是一种 tradeoff，有些情况下可能会有微弱的提升。这里的循环展开都是指完全展开。试验了一下，对这个例子，部分展开的效果不会比完全展开或者完全不展开更好。

有一个特别的现象：AVX512 理论上拥有 AVX2 两倍的吞吐量，但在我的机器上，实测二者性能几乎完全一样。

下面分别是 VTune 生成的 AoSoA / AVX512 / Loop Unrolling 和 AoSoA / AVX2 / Loop Unrolling 版本的微架构性能分析。

![avx512](https://user-images.githubusercontent.com/10691820/148420409-4acda93b-a463-46c6-8163-c6c3b6d31c32.PNG)

![avx2](https://user-images.githubusercontent.com/10691820/148420506-0ca733f7-33ec-41d4-8f2f-9e212f8b3616.PNG)


可以看到，因为使用了 AVX512，第一幅图的 Vector Capacity Usage 达到了100%，第二幅图用的是 AVX2，对应的指标只有50%。

下图是 Sunny Cove 的架构图，我的 CPU 是 Willow Cove 架构，二者基本相同。

![Sunny Cove](https://user-images.githubusercontent.com/10691820/148428600-7159d069-0aac-47fb-8ad7-e5857d3968ac.jpg)

这个图缺少很多细节，具体可以参考这个文档 (https://www.agner.org/optimize/microarchitecture.pdf) 第12章。

图中显示，10个 Ports 中，只有 Port0 支持 AVX512 浮点向量指令（包括加、乘、FMA），而 Port0 和 Port1 都支持 AVX2 浮点向量指令。但其实 Port0 那个 AVX512 浮点运算的实现是由 Port0  和 Port1 两个 AVX2 浮点运算拼成的。。。AVX512 和 AVX2 在做浮点向量运算时，吞吐量都是每个 cycle 16个 float，延迟也是一样，4个 cycles。

这与 profiler 的报告也是一致的。AVX512版本的程序中，97.5% 的 cycles 里，Port0 都在执行指令，而 Port1 大部分时间都是闲置的。对比 AVX512 的程序，Port0 和 Port1 大部分时间都在执行指令。

这个程序大部分耗时都集中在 `step()` 的内层循环。因为循环内代码存在依赖，VTune 显示其中特定的浮点向量运算（平方根倒数附近的指令）会成为性能瓶颈。因为一个 AVX512 等于两个 AVX2，所以最终效果是二者性能非常接近。

所以，对于浮点向量运算导致的 cpu core bound，AVX512 可能的确没什么作用。但如果是整数向量运算，AVX512 会有吞吐量上的优势。如果使用 AVX512，Port5 可以独立处理 16 个整数，Port0  和 Port1 拼在一起可以处理 16 个整数。用 AVX2 的话，就只能是 0，1，5 每个 Port 处理 8 个整数。另外 AVX512 在某些情况下，可能会有访存优势。

