### PR TITLE
finish hw04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 GNUmakefile
+mind.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,4 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+target_compile_options(main PUBLIC -ffast-math -march=native)

--- a/main.cpp
+++ b/main.cpp
@@ -8,32 +8,17 @@ float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
-// struct Star {
-//     float px, py, pz;
-//     float vx, vy, vz;
-//     float mass;
-// };
-
 struct Star {
     float px[48], py[48], pz[48];
     float vx[48], vy[48], vz[48];
     float mass[48];
-    float padding[512 - 336];
-    // 48 * 7 = 336 ==> padding 512 - 336;
 };
 
 Star stars;
 
-// std::vector<Star> stars;
 
 void init() {
-    /*for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
-    }*/
+
     for (int i = 0; i < 48; i++) {
         stars.px[i] = frand();
         stars.py[i] = frand();
@@ -48,28 +33,6 @@ void init() {
 float G = 0.001;
 float eps = 0.001;
 float dt = 0.01;
-
-/*
-void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
-        }
-    }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
-    }
-}
-*/
 
 
 constexpr void step() {
@@ -94,23 +57,7 @@ constexpr void step() {
     }
 
 }
-/*
-float calc() {
-    float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
-        }
-    }
-    return energy;
-}
-*/
+
 float calc() {
     float energy = 0;
 #pragma GCC unroll 4

--- a/main.cpp
+++ b/main.cpp
@@ -8,21 +8,40 @@ float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
+// struct Star {
+//     float px, py, pz;
+//     float vx, vy, vz;
+//     float mass;
+// };
+
 struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+    float px[48], py[48], pz[48];
+    float vx[48], vy[48], vz[48];
+    float mass[48];
+    float padding[512 - 336];
+    // 48 * 7 = 336 ==> padding 512 - 336;
 };
 
-std::vector<Star> stars;
+Star stars;
+
+// std::vector<Star> stars;
 
 void init() {
-    for (int i = 0; i < 48; i++) {
+    /*for (int i = 0; i < 48; i++) {
         stars.push_back({
             frand(), frand(), frand(),
             frand(), frand(), frand(),
             frand() + 1,
         });
+    }*/
+    for (int i = 0; i < 48; i++) {
+        stars.px[i] = frand();
+        stars.py[i] = frand();
+        stars.pz[i] = frand();
+        stars.vx[i] = frand();
+        stars.vy[i] = frand();
+        stars.vz[i] = frand();
+        stars.mass[i] = frand() + 1;
     }
 }
 
@@ -30,6 +49,7 @@ float G = 0.001;
 float eps = 0.001;
 float dt = 0.01;
 
+/*
 void step() {
     for (auto &star: stars) {
         for (auto &other: stars) {
@@ -49,7 +69,32 @@ void step() {
         star.pz += star.vz * dt;
     }
 }
+*/
 
+
+constexpr void step() {
+#pragma GCC unroll 4
+    for (std::size_t i = 0; i < 48; i++) {
+        for (std::size_t j = 0; j < 48; j++) {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
+            float d2 = (dx * dx) + (dy * dy) + (dz * dz) + (eps * eps);
+            d2 *= std::sqrt(d2);
+            stars.vx[i] += dx * stars.mass[j] * G * (dt / d2);
+            stars.vy[i] += dy * stars.mass[j] * G * (dt / d2);
+            stars.vz[i] += dz * stars.mass[j] * G * (dt / d2);
+        }
+    }
+#pragma GCC unroll 4
+    for (std::size_t i = 0; i < 48; i++) {
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
+    }
+
+}
+/*
 float calc() {
     float energy = 0;
     for (auto &star: stars) {
@@ -61,6 +106,23 @@ float calc() {
             float dz = other.pz - star.pz;
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
             energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+        }
+    }
+    return energy;
+}
+*/
+float calc() {
+    float energy = 0;
+#pragma GCC unroll 4
+    for (std::size_t i = 0; i < 48; i++) {
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+        for (std::size_t j = 0; j < 48; j++) {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
+            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
+            energy -= stars.mass[j] * stars.mass[i] * G / std::sqrt(d2) / 2;
         }
     }
     return energy;

--- a/mind.md
+++ b/mind.md
@@ -1,18 +1,36 @@
+设备： intel i7-6700HQ, ubuntu20.10(with GCC-9)
+
 origin time consume
 ---
 
 ```
+Before:
+
 Initial energy: -13.414000
 Final energy: -13.356842
 Time elapsed: 1519 ms
+-------------------------------------
+After:
+
+Initial energy: -13.414012
+Final energy: -13.356912
+Time elapsed: 174 ms
 ```
-- [x]因爲只有48個star，因此可以考慮unroll
-- [x] 表格中速度中最快的是soa_unroll,修改爲soa格式的速度应该会快一点。是因为SIMD吧
-- [x]别名问题使用__restrict or progma omp simd  . 这里没有函数传参数。
-- [x]除法变乘法 - 这个是不是编译器自己做的呀。
-- [x]-ffast-math
-- [x]sqrt前+std::
-- [x]可不可以改成array --> 我直接没用array直接struct嵌套数组了。
-- constexper?
-- [x]随机访问？ none
-- [x]对齐？
+
+**有用的：**
+---
+- [x]因爲只有48個star，因此可以考慮unroll。
+- [x]修改爲soa格式,使用SIMD。直接struct嵌套数组了，没使用array。
+- [x]开启-ffast-math。
+- [x]sqrt前+std:: 使用模板完成传入参数匹配。
+- [x]constexper，提高了3ms。
+
+
+
+**没用上的：**
+---
+- [ ]别名问题使用__restrict or progma omp simd  . 这里没有函数传参数。
+- [ ]除法变乘法 - 这个是不是编译器自己做的呀。
+- [ ]删除随机访问。
+- [ ]尝试了一下对齐，就添加一个padding到512byte。没有提升。
+

--- a/mind.md
+++ b/mind.md
@@ -1,0 +1,18 @@
+origin time consume
+---
+
+```
+Initial energy: -13.414000
+Final energy: -13.356842
+Time elapsed: 1519 ms
+```
+- [x]因爲只有48個star，因此可以考慮unroll
+- [x] 表格中速度中最快的是soa_unroll,修改爲soa格式的速度应该会快一点。是因为SIMD吧
+- [x]别名问题使用__restrict or progma omp simd  . 这里没有函数传参数。
+- [x]除法变乘法 - 这个是不是编译器自己做的呀。
+- [x]-ffast-math
+- [x]sqrt前+std::
+- [x]可不可以改成array --> 我直接没用array直接struct嵌套数组了。
+- constexper?
+- [x]随机访问？ none
+- [x]对齐？


### PR DESCRIPTION
设备： intel i7-6700HQ, ubuntu20.10(with GCC-9)

origin time consume
---

```
Before:

Initial energy: -13.414000
Final energy: -13.356842
Time elapsed: 1519 ms
-------------------------------------
After:

Initial energy: -13.414012
Final energy: -13.356912
Time elapsed: 174 ms
```

**有用的：**
---
- [x] 因爲只有48個star，因此可以考慮unroll。
- [x] 修改爲soa格式,使用SIMD。直接struct嵌套数组了，没使用array。
- [x] 开启-ffast-math。
- [x] sqrt前+std:: 使用模板完成传入参数匹配。
- [x] constexper，提高了3ms。



**没用上的：**
---
- [ ] 别名问题使用__restrict or progma omp simd  . 这里没有函数传参数。
- [ ] 除法变乘法 - 这个是不是编译器自己做的呀。
- [ ] 删除随机访问。
- [ ] 尝试了一下对齐，就添加一个padding到512byte。没有提升。