### PR TITLE
finish hw04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,6 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+find_package(OpenMP REQUIRED)
+target_link_libraries(main PUBLIC OpenMP::OpenMP_CXX)
+target_compile_options(main PUBLIC -ffast-math -march=native)

--- a/main.cpp
+++ b/main.cpp
@@ -4,63 +4,76 @@
 #include <chrono>
 #include <cmath>
 
-float frand() {
+static float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
-struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+struct alignas(64) Star {
+    float px[48], py[48], pz[48];
+    float vx[48], vy[48], vz[48];
+    float mass[48];
 };
 
-std::vector<Star> stars;
+Star stars;
 
 void init() {
+    #pragma GCC unroll 4
     for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+        stars.px[i] = frand();
+        stars.py[i] = frand();
+        stars.pz[i] = frand();
+        stars.vx[i] = frand();
+        stars.vy[i] = frand();
+        stars.vz[i] = frand();
+        stars.mass[i] = frand() + 1;
     }
 }
 
 float G = 0.001;
 float eps = 0.001;
+float eps_square = eps * eps;
 float dt = 0.01;
 
 void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+    #pragma GCC unroll 4
+    for (int i = 0; i < 48; i++) {
+        float px = stars.px[i], py = stars.py[i], pz = stars.pz[i];
+        float vx_plus = 0, vy_plus = 0, vz_plus = 0;
+        #pragma GCC unroll 4
+        for (int j = 0; j < 48; j++) {
+            float dx = stars.px[j] - px;
+            float dy = stars.py[j] - py;
+            float dz = stars.pz[j] - pz;
+            float d2 = dx * dx + dy * dy + dz * dz + eps_square;
+            d2 *= std::sqrt(d2);
+            float value = stars.mass[j] * (G * dt) / d2;
+            vx_plus += dx * value;
+            vy_plus += dy * value;
+            vz_plus += dz * value;
         }
+        stars.vx[i] += vx_plus;
+        stars.vy[i] += vy_plus;
+        stars.vz[i] += vz_plus;
     }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
+    #pragma GCC unroll 4
+    for (int i = 0; i < 48; i++) {
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
     }
 }
 
 float calc() {
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
+    for (int i = 0; i < 48; i++) {
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+        for (int j = 0; j < 48; j++) {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+            energy -= stars.mass[j] * stars.mass[i] * G / sqrt(d2) / 2;
         }
     }
     return energy;
@@ -79,6 +92,7 @@ int main() {
     init();
     printf("Initial energy: %f\n", calc());
     auto dt = benchmark([&] {
+        #pragma GCC unroll 64
         for (int i = 0; i < 100000; i++)
             step();
     });


### PR DESCRIPTION
### 加速之前
> Initial energy: -13.414000
Final energy: -13.356842
Time elapsed: 1373 ms
### 加速之后
> Initial energy: -13.413999
Final energy: -13.403915
Time elapsed: 100 ms
1. 将frand()函数声明为 static，有几毫秒的提升。
2. 将Star结构体的内存布局改为SOA，同时设置内存对齐（基本没有提升）
3. 将计算eps的平方放在循环外面，同时打上括号(G * dt)帮助编译器识别
4. 将px, py, pz的值在循环之外赋值给局部变量，减少读取次数。将内部循环中关于vx, vy, vz的累加，先读到局部变量，累加完毕后再写入
5. 给sqrt加 std:: 前缀，矢量化成功
6.  对小循环体用 #pragma unroll
7. 编译选项中加入-ffast-math -march=native





