### PR TITLE
完成作业

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,13 @@ cmake_minimum_required(VERSION 3.12)
 project(hellocmake LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
 add_executable(main main.cpp)
+#5th: 设置-ffast-math有奇效
+#13th: 设置-march=native 也有奇效. 至今为之，加速了10倍
+target_compile_options(main PUBLIC -ffast-math -march=native -O3)
+

--- a/main.cpp
+++ b/main.cpp
@@ -4,63 +4,99 @@
 #include <chrono>
 #include <cmath>
 
+
+//#pragma omp simd //3th: SIMD：没有明显的提升。。。可能是没有打开gcc -fopenmp -O3. 开了也没用。。
+
+constexpr int N = 48;
+
 float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
+// 2nd: SOA 反而慢了？？？。。。N太小。。
 struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+    std::vector<float> px,py,pz;
+    std::vector<float> vx,vy,vz;
+    std::vector<float> mass;
 };
-
-std::vector<Star> stars;
+Star stars;
 
 void init() {
-    for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+    for (int i = 0; i < N; i++) {
+        stars.px.push_back(frand());
+        stars.py.push_back(frand());
+        stars.pz.push_back(frand());
+        stars.vx.push_back(frand());
+        stars.vy.push_back(frand());
+        stars.vz.push_back(frand());
+        stars.mass.push_back(frand());
     }
 }
+constexpr float G = 0.001;
+constexpr float eps = 0.000001;
+constexpr float dt = 0.01;
+constexpr float G_dt = G * dt;
 
-float G = 0.001;
-float eps = 0.001;
-float dt = 0.01;
+void step()
+{
+    /*//不要展开这个10W次的大循环，反而变慢
+    for (int counter = 0; counter < 100000; counter++) //9th：把循环调用变成调用循环，没用。
+    {*/
+        //10th: 展开小循环，好像反而慢了一丢丢, 放弃治疗
+        #if defined(__GNUC__) || defined(__clang__)
+            //#pragma GCC unroll 48
+        #elif defined(_MSC_VER)
+            #pragma unroll 48
+        #endif
 
-void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+        #pragma GCC ivdep
+        for (int i = 0; i < N; i++)
+        {
+            //8th: 嵌套加法优化, 快了一丢丢
+            float dvx = 0;
+            float dvy = 0;
+            float dvz = 0;
+        
+            for (int j = 0; j < N; j++)
+            {
+                float dx = stars.px[j] - stars.px[i];
+                float dy = stars.py[j] - stars.py[i];
+                float dz = stars.pz[j] - stars.pz[i];
+                float d2 = dx * dx + dy * dy + dz * dz + eps; //11th: 提前算好eps**2， 节省1次乘法
+                d2 *= std::sqrt(d2);                   //7th: 改称std::sqrt配合ffast-math,快了一点点（大受震撼.jpg。 截至目前，快了三倍多。。。
+                dvx += dx * stars.mass[j] * G_dt / d2; //1st: 省下一次乘法, 然并卵。
+                dvy += dy * stars.mass[j] * G_dt / d2;
+                dvz += dz * stars.mass[j] * G_dt / d2;
+            }
+            stars.vx[i] += dvx;
+            stars.vy[i] += dvy;
+            stars.vz[i] += dvz;
         }
-    }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
-    }
+        #pragma GCC ivdep //12th: 好像快了一星半点？
+            
+        for (int i = 0; i < N; i++)
+        {
+            stars.px[i] += stars.vx[i] * dt;
+            stars.py[i] += stars.vy[i] * dt;
+            stars.pz[i] += stars.vz[i] * dt;
+        }
+    /*}*/
 }
 
-float calc() {
+float calc()
+{
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+    for (int i = 0; i < N; i++)
+    {
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+        for (int j = 0; j < N; j++)
+        {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
+            float d2 = dx * dx + dy * dy + dz * dz + eps;
+            energy -= stars.mass[j] * stars.mass[i] * G / std::sqrt(d2) / 2;
         }
     }
     return energy;
@@ -79,7 +115,7 @@ int main() {
     init();
     printf("Initial energy: %f\n", calc());
     auto dt = benchmark([&] {
-        for (int i = 0; i < 100000; i++)
+        for(int i = 0;i<100000;i++)
             step();
     });
     printf("Final energy: %f\n", calc());

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 
-//#pragma omp simd //3th: SIMD：没有明显的提升。。。可能是没有打开gcc -fopenmp -O3. 开了也没用。。
+//#pragma omp simd //3rd: SIMD：没有明显的提升。。。可能是没有打开gcc -fopenmp -O3. 开了也没用。。
 
 constexpr int N = 48;
 


### PR DESCRIPTION
一共进行了9处优化，如注释中所标记。
1. 将$G,eps,dt$等常量换成constexpr，在编译期求值，并提前计算出G*dt 记录在G_dt中，在每次循环中省下一次乘法，略有功效。
2. 将`Star`改成SOA，方便编译器进行SIMD优化。但应该是由于`N = 48`太小，没有显著的效果。
3. `#pragma omp simd`强制SIMD好像没啥用。注释掉看`objdump -D main`基本都是qs，没什么影响，就不开了。
4. 不知道写的啥，被我删除了。。。。。
5. CMakeLists.txt中加入`-ffast-math -O3`效果显著。之所以可以放心开是因为代码里$d2 \ge eps^2 \ge 0$，不会出现0分母。
6. 被删除了
7. 把`sqrt`改成`std::sqrt`有效果。大受震撼。
8. 将嵌套加法的结果记录在临时变量里，让编译器放心数组没有重叠。
9. 将main中100000步循环放进step里，效果不行，删了。
10. 将step中的48次循环展开，反而慢了。。。删。。。
11. 提前将$eps^2$算好，可能会快一丢丢？。
12. 加入ivdep让编译器忽略指针别名，有一点点效果。
13. 在CMakeLists.txt中设置`-march=native`，有奇效。据`objdump`观测，大批xmm投入了ymm的怀抱，直接快了几倍。不过一个ymm = 2个xmm的话，不应该是至多是原来两倍吗，怎么实测好像近3倍。想不明白。