### PR TITLE
Hw04/simd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,6 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+target_compile_options(main PUBLIC -ffast-math -march=native)
+find_package(OpenMP REQUIRED)
+target_link_libraries(main PUBLIC OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,3 @@ endif()
 
 add_executable(main main.cpp)
 target_compile_options(main PUBLIC -ffast-math -march=native)
-find_package(OpenMP REQUIRED)
-target_link_libraries(main PUBLIC OpenMP::OpenMP_CXX)

--- a/main.cpp
+++ b/main.cpp
@@ -8,60 +8,94 @@ float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
+constexpr size_t length = 48;
 struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+    float px[length], py[length], pz[length];
+    float vx[length], vy[length], vz[length];
+    float mass[length];
 };
 
-std::vector<Star> stars;
+Star stars;
 
 void init() {
-    for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+    #pragma omp simd
+    for (size_t i = 0; i < length; i++) {
+        stars.px[i] = frand();
+        stars.py[i] = frand();
+        stars.pz[i] = frand();
+        stars.vx[i] = frand();
+        stars.vy[i] = frand();
+        stars.vz[i] = frand();
+        stars.mass[i] = frand() + 1;
     }
 }
 
-float G = 0.001;
-float eps = 0.001;
-float dt = 0.01;
+constexpr float G = 0.001;
+constexpr float eps = 0.001;
+constexpr float dt = 0.01;
+// 提前计算, 减少不必要的乘法
+constexpr float Gdt = G * dt;
+constexpr float eps2 = eps * eps;
+constexpr float G2 = G / 2;
 
 void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+    for (size_t i = 0; i < length; i++) {
+        // 减少不必要的内存访问
+        float spxi = stars.px[i];
+        float spyi = stars.py[i];
+        float spzi = stars.pz[i];
+
+        // 先累加到初始化为0的局部变量
+        float tmp_vxi = 0;
+        float tmp_vyi = 0;
+        float tmp_vzi = 0;
+        
+        for (size_t j = 0; j < length; j++) {
+            float dx = stars.px[j] - spxi;
+            float dy = stars.py[j] - spyi;
+            float dz = stars.pz[j] - spzi;
+            float d2 = dx * dx + dy * dy + dz * dz + eps2;
+            d2 *= std::sqrt(d2);
+            tmp_vxi += dx * stars.mass[j] * Gdt / d2;
+            tmp_vyi += dy * stars.mass[j] * Gdt / d2;
+            tmp_vzi += dz * stars.mass[j] * Gdt / d2;
         }
+        // 累加结束后再写入到全局变量中
+        stars.vx[i] += tmp_vxi;
+        stars.vy[i] += tmp_vyi;
+        stars.vz[i] += tmp_vzi;
     }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
+
+    for (size_t i = 0; i < length; i++) {
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
     }
 }
 
 float calc() {
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+    for (size_t i = 0; i < length; i++) {
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] + stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+
+        // 减少不必要的内存访问
+        float pxi = stars.px[i];
+        float pyi = stars.py[i];
+        float pzi = stars.pz[i];
+        float massi = stars.mass[i];
+
+        // 先累加到初始化为0的局部变量
+        float tmp = 0;
+        for (size_t j = 0; j < length; j++) {
+            float dx = stars.px[j] - pxi;
+            float dy = stars.py[j] - pyi;
+            float dz = stars.pz[j] - pzi;
+            float d2 = dx * dx + dy * dy + dz * dz + eps2;
+            tmp += stars.mass[j] * massi * G2 / std::sqrt(d2);
         }
+        // 累加结束后写入
+        energy -= tmp;
     }
     return energy;
 }


### PR DESCRIPTION
原始版本
Initial energy: -13.41400
Final energy: -13.356842
Time eplased: 1812 ms

SIMD加速版本
Initial energy: -13.414012
Final energy: -13.403986
Time elapsed: 195 ms

* AOS 转换为 SOA 分离存储多个属性便于SIMD优化
* 数学优化
    * 除法变乘法：让`1.f / RAND_MAX * 2`编译期求值，这样使得`frand()`内部的1次除法和1次乘法变成1次乘法
    * 提前计算公共乘法：让`G * dt`、`eps * eps`、`G / 2`在编译期求值，减少乘法次数
* 设置局部变量减少不必要的内存访问：`step()`和`calc()`的内部循环要使用外部循环中的值，在外部循环设置变量保存需要用的值，减少访存
* 使用局部变量便于SIMD优化，且让结果更加精确以及能让公共乘数放到外部循环
    * `step()`函数中`stars.vx[i],stars.vy[i],stars.vz[i]`的累加都使用局部变量替代，内部循环结束后再乘以公共乘数再累加，减少内部循环的乘法次数
    * `calc()`函数中内部循环也是先用局部变量累加，结束后再乘以公共乘数，随后累加到`energy`中