### PR TITLE
使用了SOA在内的各种优化方法

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+
+find_package(OpenMP REQUIRED)
+target_link_libraries(main PUBLIC OpenMP::OpenMP_CXX)
+target_compile_options(main PUBLIC -ffast-math -march=native)

--- a/main.cpp
+++ b/main.cpp
@@ -4,63 +4,72 @@
 #include <chrono>
 #include <cmath>
 
-float frand() {
+static float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
 struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
+    float px[48], py[48], pz[48];
+    float vx[48], vy[48], vz[48];
+    float mass[48];
 };
 
-std::vector<Star> stars;
+Star stars;
+
+constexpr size_t pnum = 48;
 
 void init() {
-    for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+    for (size_t i = 0; i < pnum; i++) {
+        stars.px[i]=frand();
+        stars.py[i]=frand();
+        stars.pz[i]=frand();
+        stars.vx[i]=frand();
+        stars.vy[i]=frand();
+        stars.vz[i]=frand();
+        stars.mass[i]=frand()+1;
     }
 }
 
 float G = 0.001;
 float eps = 0.001;
 float dt = 0.01;
+float eps2 = eps*eps;
+float Gpdt = G * dt;
 
 void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+#pragma GCC ivdep
+    for (size_t i=0; i<pnum; i++) {
+        for (size_t j=0; j<pnum; j++) {
+            float dx = stars.px[j]-stars.px[i];
+            float dy = stars.py[j]-stars.py[i];
+            float dz = stars.pz[j]-stars.pz[i];
+            float d2 = dx*dx + dy*dy + dz*dz + eps2;
+            d2 *= std::sqrt(d2);
+            stars.vx[i] += dx * stars.mass[j] * Gpdt / d2;
+            stars.vy[i] += dy * stars.mass[j] * Gpdt / d2;
+            stars.vz[i] += dz * stars.mass[j] * Gpdt / d2;
         }
     }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
+    for (size_t i = 0; i<pnum; i++) {
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
     }
+    
 }
 
 float calc() {
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
-            float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+#pragma GCC ivdep
+    for (size_t i = 0; i<pnum; i++) {
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+        for (size_t j = 0; j<pnum; j++) {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
+            float d2 = dx*dx + dy*dy + dz*dz + eps2;
+            energy -= stars.mass[j] * stars.mass[i] * G / std::sqrt(d2) / 2;
         }
     }
     return energy;

--- a/main.cpp
+++ b/main.cpp
@@ -38,6 +38,7 @@ float Gpdt = G * dt;
 
 void step() {
 #pragma GCC ivdep
+// #pragma omp simd
     for (size_t i=0; i<pnum; i++) {
         for (size_t j=0; j<pnum; j++) {
             float dx = stars.px[j]-stars.px[i];
@@ -61,6 +62,7 @@ void step() {
 float calc() {
     float energy = 0;
 #pragma GCC ivdep
+// #pragma omp simd
     for (size_t i = 0; i<pnum; i++) {
         float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
         energy += stars.mass[i] * v2 / 2;


### PR DESCRIPTION
### 使用的优化方法
将AOS改为了SOA，vector改为原生数组，for循环int改为size_t，将循环中不必要的计算提出来，使用了std的数学函数，开启了浮点运算的优化选项。
提升最大的还是浮点优化选项，速度快了不止一倍，而是大概6倍的提升。
试了AOS结构体数据对齐的操作，发现并不比SOA慢，可能是数据量还有不同设备的差别引起的。

### 执行时间对比

- 优化前：

>     Initial energy: -13.414000
>     Final energy: -13.356842
>     Time elapsed: 2838 ms

- 优化后：

>     Initial energy: -13.414012
>     Final energy: -13.356912
>     Time elapsed: 286 ms