### PR TITLE
finish hw04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,4 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_executable(main main.cpp)
+target_compile_options(main PUBLIC -ffast-math -march=native)

--- a/main.cpp
+++ b/main.cpp
@@ -8,59 +8,83 @@ float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
-struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
-};
+const int MAXLEN = 48;
 
-std::vector<Star> stars;
+struct Star {
+    float px[MAXLEN], py[MAXLEN], pz[MAXLEN];
+    float vx[MAXLEN], vy[MAXLEN], vz[MAXLEN];
+    float mass[MAXLEN];
+} stars;
 
 void init() {
-    for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+    for (int i = 0; i < MAXLEN; i++) {
+        stars.px[i] = frand();
+        stars.py[i] = frand();
+        stars.pz[i] = frand();
+        stars.vx[i] = frand();
+        stars.vy[i] = frand();
+        stars.vz[i] = frand();
+        stars.mass[i] = frand() + 1;
     }
 }
 
-float G = 0.001;
-float eps = 0.001;
-float dt = 0.01;
+const float G = 0.001;
+const float eps = 0.001;
+const float dt = 0.01;
+
+const float Gdt = G * dt;
 
 void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
+    for (size_t i = 0; i < MAXLEN; ++i)
+    {
+        for (size_t j = 0; j < MAXLEN; ++j)
+        {
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+            d2 = 1 / std::sqrt(d2);
+            d2 = d2 * d2 * d2;
+            stars.vx[i] += dx * stars.mass[j] * Gdt * d2;
+            stars.vy[i] += dy * stars.mass[j] * Gdt * d2;
+            stars.vz[i] += dz * stars.mass[j] * Gdt * d2;
         }
     }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
+    
+    // for (auto &star: stars) {
+    //     for (auto &other: stars) {
+    //         float dx = other.px - star.px;
+    //         float dy = other.py - star.py;
+    //         float dz = other.pz - star.pz;
+    //         float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
+    //         d2 = 1 / std::sqrt(d2);
+    //         d2 = d2 * d2 * d2;
+            
+    //     }
+    // }
+
+    for(size_t i = 0; i < MAXLEN; ++i) {
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
     }
 }
 
 float calc() {
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
+    for (size_t i = 0; i < MAXLEN; ++i)
+    {
+        float starvx = stars.vx[i], starvy = stars.vy[i], starvz = stars.vz[i];
+        float starpx = stars.px[i], starpy = stars.py[i], starpz = stars.pz[i];
+        float starmass = stars.mass[i];
+        float v2 = starvx * starvx + starvy * starvy + starvz * starvz;
+        energy += starmass * v2 / 2;
+        for (size_t j = 0; j < MAXLEN; ++j) {
+            float dx = stars.px[j] - starpx;
+            float dy = stars.py[j] - starpy;
+            float dz = stars.pz[j] - starpz;
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+            energy -= stars.mass[j] * starmass * G / sqrt(d2) / 2;
         }
     }
     return energy;


### PR DESCRIPTION
## 优化效果
环境：Win10 WLS/Ubuntu 20.04 + GCC9.3.0_x86_64

 优化手段 | 耗时 | 加速比
---| --- | ---
initial | 6275 ms | 1 
AOS -> SOA | 4338 ms | 1.45
AOS -> SOA -O3 | 1695 ms | 3.70
AOS -> SOA -O3 -ffast-math -march=native | 182 ms | 34.48

##  说明

- AOS -> SOA 
1. 修改 `stars` 为 Struct of Array 的类型，修改相应的计算代码。这里用 C array 而不是 `std::array<float, N>` 因为感觉没有必要上模板（计算逻辑不是十分依赖STL与模板，有时间可以比较两种数组的优化）。
2. 并提取部分公共子表达式，如 `G * dt` 。将部分常量用 `const` 修饰以期 compiler 优化。值得注意的是，不是所有公共表达式都需要提取，如 `1 / RAND_MAX * 2` 就不能。因为 `1 / RAND_MAX` 就是 `0.0f` ，这会导致计算逻辑错误。
- -O3 -ffast-math -march=native 
开启编译器优化前后，对比汇编代码，在优化后 `step` 函数原来的标量计算指令，许多都被替换成 `mulps`、`addps` 与 `shufps` 等 SIMD 指令的结合操作，而且有循环的展开，使得计算速度大幅提升。