### PR TITLE
finish hw4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,6 @@ set(CMAKE_CXX_STANDARD 17)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ffast-math -march=native")  
 
 add_executable(main main.cpp)

--- a/main.cpp
+++ b/main.cpp
@@ -1,28 +1,28 @@
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
+#include <array>
 #include <chrono>
 #include <cmath>
-
+#include <sys/cdefs.h>
 float frand() {
     return (float)rand() / RAND_MAX * 2 - 1;
 }
 
 struct Star {
-    float px, py, pz;
-    float vx, vy, vz;
-    float mass;
-};
-
-std::vector<Star> stars;
+    float px[48], py[48], pz[48];
+    float vx[48], vy[48], vz[48];
+    float mass[48];
+}stars;
 
 void init() {
     for (int i = 0; i < 48; i++) {
-        stars.push_back({
-            frand(), frand(), frand(),
-            frand(), frand(), frand(),
-            frand() + 1,
-        });
+        stars.px[i] = frand();
+        stars.py[i] = frand();
+        stars.pz[i] = frand();
+        stars.vx[i] = frand();
+        stars.vy[i] = frand();
+        stars.vz[i] = frand();
+        stars.mass[i] = frand() + 1;    
     }
 }
 
@@ -30,44 +30,44 @@ float G = 0.001;
 float eps = 0.001;
 float dt = 0.01;
 
-void step() {
-    for (auto &star: stars) {
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
+static void step() {
+    for(int i=0;i<48;++i){
+        for(int j=0;j<48;++j){
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            d2 *= sqrt(d2);
-            star.vx += dx * other.mass * G * dt / d2;
-            star.vy += dy * other.mass * G * dt / d2;
-            star.vz += dz * other.mass * G * dt / d2;
+            d2 *= std::sqrt(d2);
+            stars.vx[i] += dx * (stars.mass[j] * G * dt / d2);
+            stars.vy[i] += dy * (stars.mass[j] * G * dt / d2);
+            stars.vz[i] += dz * (stars.mass[j] * G * dt / d2);
         }
     }
-    for (auto &star: stars) {
-        star.px += star.vx * dt;
-        star.py += star.vy * dt;
-        star.pz += star.vz * dt;
+    for(int i=0;i<48;++i){
+        stars.px[i] += stars.vx[i] * dt;
+        stars.py[i] += stars.vy[i] * dt;
+        stars.pz[i] += stars.vz[i] * dt;
     }
 }
 
 float calc() {
     float energy = 0;
-    for (auto &star: stars) {
-        float v2 = star.vx * star.vx + star.vy * star.vy + star.vz * star.vz;
-        energy += star.mass * v2 / 2;
-        for (auto &other: stars) {
-            float dx = other.px - star.px;
-            float dy = other.py - star.py;
-            float dz = other.pz - star.pz;
+    for(int i=0;i<48;++i){
+        float v2 = stars.vx[i] * stars.vx[i] + stars.vy[i] * stars.vy[i] + stars.vz[i] * stars.vz[i];
+        energy += stars.mass[i] * v2 / 2;
+        for(int j=0;j<48;++j){
+            float dx = stars.px[j] - stars.px[i];
+            float dy = stars.py[j] - stars.py[i];
+            float dz = stars.pz[j] - stars.pz[i];
             float d2 = dx * dx + dy * dy + dz * dz + eps * eps;
-            energy -= other.mass * star.mass * G / sqrt(d2) / 2;
+            energy -= stars.mass[j] * stars.mass[i] * G / sqrt(d2) / 2;
         }
     }
     return energy;
 }
 
 template <class Func>
-long benchmark(Func const &func) {
+static long benchmark(Func const &func) {
     auto t0 = std::chrono::steady_clock::now();
     func();
     auto t1 = std::chrono::steady_clock::now();


### PR DESCRIPTION
初始数据
Initial energy: -13.414000
Final energy: -13.356842
Time elapsed: 1758 ms


(other.mass * G * dt / d2) 把重复计算的部分括号起来，编译器会将其移动到循环外。这步减少了大量计算。也帮助矢量化
Initial energy: -13.414000
Final energy: -13.356842
Time elapsed: 1273 ms

sqrt使用std，std里的函数优化更好
Initial energy: -13.414000
Final energy: -13.356842
Time elapsed: 1131 ms

添加优化指令-O3 -ffast-math -march=native，-ffast-math 选项让 GCC 更大胆地尝试浮点运算的优化，-O3提升优化等级。
-march=native指示编译器生成针对当前编译代码的机器上运行的CPU架构进行优化的代码
Initial energy: -13.413999
Final energy: -13.380254
Time elapsed: 359 ms
但是优化后精度出现了问题

修改成SOA。把所有的变量都变成数组的形式，当计算的时候就可以实现simd
Initial energy: -13.413999
Final energy: -13.356841
Time elapsed: 123 ms

其他的优化比如AOSOA，循环展开，除法变乘法, constexpr等等基本上都没什么提升。估计编译器本身就已经有优化了吧。
总共只提升了10倍左右。